### PR TITLE
Messaging CONNECTION_REFUSED error fix

### DIFF
--- a/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/producers/AbstractMessageProducer.java
+++ b/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/producers/AbstractMessageProducer.java
@@ -15,18 +15,28 @@ import java.util.concurrent.TimeoutException;
 
 public abstract class AbstractMessageProducer {
 
-	private static final String HOST = PropertyUtil.getProperty("app.rabbitmq.host");
+	public static final String HOST = PropertyUtil.getProperty("app.rabbitmq.host");
+	public static final String V_HOST = PropertyUtil.getProperty("app.rabbitmq.vhost");
+	public static final String USERNAME = PropertyUtil.getProperty("app.rabbitmq.user");
+	public static final String PASSWORD = PropertyUtil.getProperty("app.rabbitmq.pass");
 
 	private ConnectionFactory factory;
 	protected Serializable message;
 
 	public AbstractMessageProducer(Serializable message) {
-		factory = new ConnectionFactory();
-		factory.setHost(HOST);
+		initConnFactory();
 
 		this.message = message;
 
 		connectAndSendMessage();
+	}
+
+	private void initConnFactory() {
+		factory = new ConnectionFactory();
+		factory.setHost(HOST);
+		factory.setVirtualHost(V_HOST);
+		factory.setUsername(USERNAME);
+		factory.setPassword(PASSWORD);
 	}
 
 	protected abstract String getQueueName();

--- a/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/receivers/UserNotificationReceiver.java
+++ b/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/receivers/UserNotificationReceiver.java
@@ -1,6 +1,7 @@
 package com.mantzavelas.tripassistantapi.messaging.receivers;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.mantzavelas.tripassistantapi.messaging.producers.AbstractMessageProducer;
 import com.mantzavelas.tripassistantapi.models.Trip;
 import com.mantzavelas.tripassistantapi.models.User;
 import com.mantzavelas.tripassistantapi.models.UserNotification;
@@ -10,7 +11,6 @@ import com.mantzavelas.tripassistantapi.repositories.UserRepository;
 import com.mantzavelas.tripassistantapi.services.FirebaseCloudMessagingService;
 import com.mantzavelas.tripassistantapi.utils.BeanUtil;
 import com.mantzavelas.tripassistantapi.utils.EncryptUtil;
-import com.mantzavelas.tripassistantapi.utils.PropertyUtil;
 import com.mantzavelas.tripassistantapi.utils.StringUtil;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 public class UserNotificationReceiver {
 
 	private static final String QUEUE_NAME = "trip.notification";
-	private static final String HOST = PropertyUtil.getProperty("app.rabbitmq.host");
 
 	private ConnectionFactory factory;
 	private UserNotificationRepository repository = BeanUtil.getBean(UserNotificationRepository.class);
@@ -35,7 +34,10 @@ public class UserNotificationReceiver {
 
 	public UserNotificationReceiver() {
 		factory = new ConnectionFactory();
-		factory.setHost(HOST);
+		factory.setHost(AbstractMessageProducer.HOST);
+		factory.setVirtualHost(AbstractMessageProducer.V_HOST);
+		factory.setUsername(AbstractMessageProducer.USERNAME);
+		factory.setPassword(AbstractMessageProducer.PASSWORD);
 
 		initQueueConnection();
 	}

--- a/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/test/Receiver.java
+++ b/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/test/Receiver.java
@@ -1,5 +1,6 @@
 package com.mantzavelas.tripassistantapi.messaging.test;
 
+import com.mantzavelas.tripassistantapi.messaging.producers.AbstractMessageProducer;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
@@ -13,7 +14,11 @@ public class Receiver {
 
 	public static void main(String[] args) throws Exception {
 		ConnectionFactory factory = new ConnectionFactory();
-		factory.setHost("localhost");
+		factory.setHost(AbstractMessageProducer.HOST);
+		factory.setVirtualHost(AbstractMessageProducer.V_HOST);
+		factory.setUsername(AbstractMessageProducer.USERNAME);
+		factory.setPassword(AbstractMessageProducer.PASSWORD);
+
 		Connection connection = factory.newConnection();
 		Channel channel = connection.createChannel();
 

--- a/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/test/Sender.java
+++ b/tripassistant-api/src/main/java/com/mantzavelas/tripassistantapi/messaging/test/Sender.java
@@ -1,5 +1,6 @@
 package com.mantzavelas.tripassistantapi.messaging.test;
 
+import com.mantzavelas.tripassistantapi.messaging.producers.AbstractMessageProducer;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
@@ -13,10 +14,13 @@ public class Sender {
 
 	public static void main(String[] args) {
 		ConnectionFactory factory = new ConnectionFactory();
-		factory.setHost("localhost");
+		factory.setHost(AbstractMessageProducer.HOST);
+		factory.setVirtualHost(AbstractMessageProducer.V_HOST);
+		factory.setUsername(AbstractMessageProducer.USERNAME);
+		factory.setPassword(AbstractMessageProducer.PASSWORD);
+
 		try (Connection connection = factory.newConnection();
 			Channel channel = connection.createChannel()) {
-
 			channel.queueDeclare(QUEUE_NAME, false, false, false, null);
 			String message = "Test Message!!!";
 			channel.basicPublish("", QUEUE_NAME, null, message.getBytes());

--- a/tripassistant-api/src/main/resources/application.properties
+++ b/tripassistant-api/src/main/resources/application.properties
@@ -1,6 +1,24 @@
+#spring.datasource.url =
+#spring.datasource.username =
+#spring.datasource.password =
 
+#spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
-app.jwtSecret= JWTSuperSecretKey
+#app.jwtSecret=
 app.jwtExpirationInSec = 3600
+
+#apiClient.facebook.clientId =
+#apiClient.facebook.secret =
+#apiClient.flickr.apiKey =
+#apiClient.flickr.secret =
+
+#app.rabbitmq.host =
+#app.rabbitmq.vhost =
+#app.rabbitmq.user =
+#app.rabbitmq.pass =
+#app.fcm.dbName =
+
+#app.security.encPassword =
+#app.security.encSalt =


### PR DESCRIPTION
Fixed an issue with rabbitmq connectivity.
Was getting Connection Refused when trying to declare a queue.
By default guest user account was used which is only allowed permissions from localhost.
So set to ConnectionFactory the virtual host, username, password to resolve this